### PR TITLE
Add exit codes for main method

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -54,6 +54,19 @@ class DynamoDBTable(Enum):
         })
 
 
+class TwitterBotExitCodes(Enum):
+    """Exit codes for the possible outcomes of the main method."""
+
+    OK = 0
+    UNHANDLED = 1
+    MAX_TWEETS_EXCEEDED = 2
+    NO_WORDS_LEFT = 3
+    BAD_DICTIONARY_RESPONSE = 4
+    NO_DICTIONARY_ENTRY = 5
+    TWEET_FAILED = 6
+    DB_FAILED = 7
+
+
 # The maximum number of characters allowed in a Tweet.
 TWEET_MAX_CHARS = 280
 # The length to which URLs are modified during Tweet creation.

--- a/tests/test_twitter_bot/test_twitter_bot.py
+++ b/tests/test_twitter_bot/test_twitter_bot.py
@@ -4,6 +4,7 @@ from aws_client import get_tweets_on_date
 from aws_client import put_item
 from collections import namedtuple
 from constants import DynamoDBTable
+from constants import TwitterBotExitCodes
 from contextlib import redirect_stderr
 from contextlib import redirect_stdout
 from datetime import date
@@ -78,7 +79,9 @@ class TestTwitterBot(TestDynamoDBMixin):
         out, err = StringIO(), StringIO()
         with redirect_stdout(out):
             with redirect_stderr(err):
-                run_twitter_bot()
+                with self.assertRaises(SystemExit) as cm:
+                    run_twitter_bot()
+                self.assertEqual(cm.exception.code, TwitterBotExitCodes.OK)
         self.assertFalse(err.getvalue())
         output = out.getvalue()
         self.assert_success_message(output, dt, date_entry)


### PR DESCRIPTION
**Changes**
- Added a class `TwitterBotExitCodes`, which contains exit codes for each outcome of the `main` method (e.g., the maximum number of Tweets have been tweeted today, there are no words left to process, the Tweet failed, etc.).
- Replaced `return` with `sys.exit(error_code)` in `main`.
- Updated tests.