### PR TITLE
Add scripts for zipping files needed for Lambda

### DIFF
--- a/deploy/zip_code.sh
+++ b/deploy/zip_code.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Create a zip file in /tmp containing the contents of the given
+# directory.
+
+SRC_DIR=$1
+TMP_DIR="/tmp/lambda_code"
+
+mkdir -p $TMP_DIR
+
+rsync -a $SRC_DIR $TMP_DIR --exclude .git/ --exclude __pycache__/
+
+cd $TMP_DIR/$(basename $SRC_DIR)
+zip -r "${TMP_DIR}.zip" ./*
+
+rm -rf $TMP_DIR

--- a/deploy/zip_pip_requirements.sh
+++ b/deploy/zip_pip_requirements.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Create a zip file in /tmp containing installed Python modules listed
+# in the given Pip requirements file.
+
+REQUIREMENTS_FILE=$1
+TMP_DIR="/tmp/lambda_pip_requirements"
+PACKAGES_DIR="${TMP_DIR}/packages/python/lib/python3.8/site-packages"
+VENV_DIR="${TMP_DIR}/venv"
+
+mkdir -p $TMP_DIR
+mkdir -p $PACKAGES_DIR
+mkdir -p $VENV_DIR
+python3.8 -m venv $VENV_DIR
+
+. $VENV_DIR/bin/activate
+pip install --target $PACKAGES_DIR -r $REQUIREMENTS_FILE
+deactivate
+
+cd $PACKAGES_DIR
+zip -r "${TMP_DIR}.zip" ./*
+
+rm -rf $TMP_DIR


### PR DESCRIPTION
Fixes #14

**Changes**
- Added a Bash script that creates a zip file, containing the contents of a given directory, in `/tmp`. This is intended to zip the source code directory containing `lambda_function.py`.
- Added a Bash script that creates a zip file, containing the installed Python modules listed in the given Pip requirements file.